### PR TITLE
add example fetches

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 GATSBY_ROOT_URL=https://tracer.finance
+
+API_URL=https://mycelium-content.uc.r.appspot.com

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,6 +16,13 @@ module.exports = {
       },
     },
     {
+      resolve: "gatsby-source-strapi",
+      options: {
+        apiURL: process.env.API_URL || "ttps://mycelium-content.uc.r.appspot.com/",
+        collectionTypes: ["hd-podcasts"],
+      },
+    },
+    {
       resolve: "gatsby-source-filesystem",
       options: {
         name: 'src',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gatsby-remark-relative-images": "^2.0.2",
     "gatsby-remark-remove-root-p-tag": "^1.0.1",
     "gatsby-source-filesystem": "^2.11.1",
-    "gatsby-source-strapi": "^0.0.12",
+    "gatsby-source-strapi": "^1.0.1",
     "gatsby-transformer-remark": "^2.16.1",
     "gatsby-transformer-sharp": "^2.12.1",
     "gsap": "^3.6.1",

--- a/src/pages/listen.js
+++ b/src/pages/listen.js
@@ -8,7 +8,39 @@ import Footer from '../components/footer'
 // Images
 import hd_logo from '../../static/img/listen/high-definition-logo.svg';
 
+export const query = graphql`
+  query AllPodcasts {
+    allStrapiHdPodcasts {
+      edges {
+        node {
+          captivate_link
+          description
+          episode
+          duration
+          guest
+          img {
+            formats {
+              medium {
+                url
+              }
+            }
+          }
+          recorded_on(formatString: "")
+          slug
+          release_date(formatString: "")
+          youtube_link
+          transcript
+        }
+      }
+    }
+  }
+`;
+
 class Listen extends Component {
+  constructor (props) {
+    super();
+    console.log(props.data, "This is all the podcasts")
+  }
   render() {
     return (
       <>

--- a/src/pages/listen/{StrapiHdPodcasts.slug}.js
+++ b/src/pages/listen/{StrapiHdPodcasts.slug}.js
@@ -1,18 +1,48 @@
 /* eslint-disable */
 import React, { Component } from "react";
-import Article from '../components/article'
-import SEO from '../components/seo';
-import Layout from '../components/layout';
-import Footer from '../components/footer'
-import Episode from '../components/episode'
+import Article from '../../components/article'
+import SEO from '../../components/seo';
+import Layout from '../../components/layout';
+import Footer from '../../components/footer'
+import Episode from '../../components/episode'
 
 // Image assets
-import hd_thumbnail from '../../static/img/listen/thumbnail.svg';
-import player_img from '../../static/img/article/player.png';
-import player_img_small from '../../static/img/article/player_mobile.png';
-import video_placeholder from '../../static/img/article/video_placeholder.png';
+import hd_thumbnail from '../../../static/img/listen/thumbnail.svg';
+import player_img from '../../../static/img/article/player.png';
+import player_img_small from '../../../static/img/article/player_mobile.png';
+import video_placeholder from '../../../static/img/article/video_placeholder.png';
 
+export const query = graphql`
+  query StrapiHdPodcasts($slug: String!) {
+    strapiHdPodcasts(slug: { eq: $slug }) {
+      captivate_link
+      description
+      duration
+      episode
+      guest
+      img {
+        formats {
+          medium {
+            url
+          }
+        }
+      }
+      meeting_notes {
+        description
+        note
+        notes
+        title
+      }
+      slug
+      transcript
+      youtube_link
+    }
+  }
+`;
 class EpisodePage extends Component {
+  constructor(props) {
+    console.log(props)
+  }
   render() {
     return (
       <>


### PR DESCRIPTION
Sorry was also out last night. Strapi's docs are a bit hopeless but just added the code to fetch all podcasts, you can see the logs in props. You'll then have to do something with the content, but you can access it just like props.data.strapiBlog.description or whatever it is. 

Thanks for doing this in React as well, I know it might seem like more annoying and effort to set it up but i'll have to show you some cool things you can do in something like React which makes things a lot easier.